### PR TITLE
feat: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,18 @@ accepts: `multipart/form-data`
   "file": "file"
 }
 ```
-response: `200 OK`
+response: `201 CREATED`
 
-TBA
+```json
+{
+    "data": {
+        "fileName": "7u94qd.jpg",
+        "fileType": "image/jpeg",
+        "size": 48003
+    },
+    "message": "File uploaded with success!"
+}
+```
 
 ### 2. Download file
 
@@ -74,13 +83,11 @@ method: `GET`
 
 url: `{baseUrl}/api/v1/files/download?filename={filename}`
 
-accepts: `application/json`
-
 request params: `filename`
 
 response: `200 OK`
 
-TBA
+content-type: `application/octet-stream`
 
 ### 3. Delete file
 
@@ -88,12 +95,15 @@ method: `DELETE`
 
 url: `{baseUrl}/api/v1/files?filename={filename}`
 
-accepts: `application/json`
-
 request params: `filename`
 
 response: `200 OK`
 
-TBA
+```json
+{
+    "data": null,
+    "message": "7u94qd.jpg has deleted with success!"
+}
+```
 
 If you have **scenario to store url of the file in database**, you can save it with pattern `{miniO-api-host}/{bucket-name}/{filename}` but the bucket must be set to public


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to provide more detailed responses and content types for the file upload, download, and delete operations. The changes improve the documentation by specifying the expected responses and content types for these API endpoints.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R107): Updated the response for the file upload operation to `201 CREATED` and provided a sample JSON response.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R107): Added `content-type: application/octet-stream` for the file download operation.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R107): Provided a sample JSON response for the file delete operation.